### PR TITLE
fix/http.messageBinding_yaml: messageBinding.bindingVersion instead o…

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -93,8 +93,7 @@ channels:
                 Content-Type:
                   type: string
                   enum: ['application/json']
-            meta:
-              version: '0.1.0'
+            bindingVersion: '0.1.0'
 ```
 
 [schemaObject]: https://www.asyncapi.com/docs/specifications/2.0.0/#schemaObject


### PR DESCRIPTION
Issue: https://github.com/asyncapi/bindings/issues/19

**Description**
- Changed `meta` to `bindingVersion` in Message Binding section of HTTP Bindings documentation.

**Related issue(s)**
`Fixes#19`
