### PR TITLE
fix: description for MQTT QoS for Operation Binding Object

### DIFF
--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -68,7 +68,7 @@ This object contains information about the operation representation in MQTT.
 
 Field Name | Type | Applies To | Description
 ---|:---:|:---:|---
-<a name="operationBindingObjectQoS"></a>`qos` | integer | Publish, Subscribe | Defines how hard the broker/client will try to ensure that a message is received. Its value MUST be either 0, 1 or 2.
+<a name="operationBindingObjectQoS"></a>`qos` | integer | Publish, Subscribe | Defines the Quality of Service (QoS) levels for the message flow between client and server. Its value MUST be either 0 (At most once delivery), 1 (At least once delivery), or 2 (Exactly once delivery).
 <a name="operationBindingObjectRetain"></a>`retain` | boolean | Publish, Subscribe | Whether the broker should retain the message or not.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | Publish, Subscribe | The version of this binding. If omitted, "latest" MUST be assumed.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- The field `qos` in the MQTT Bindings is described quite differently than in the specification:
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718099

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->