### PR TITLE
fix: move WebSockets binding details to server and remove the method option

### DIFF
--- a/websockets/README.md
+++ b/websockets/README.md
@@ -6,15 +6,22 @@ This document defines how to describe WebSockets-specific information on AsyncAP
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `0.2.0`.
 
 
 <a name="server"></a>
 
 ## Server Binding Object
 
-This object MUST NOT contain any properties. Its name is reserved for future use.
+##### Fixed Fields
 
+Field Name | Type | Description
+---|:---:|---
+<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
+
+This object MUST contain only the properties defined above.
 
 
 
@@ -22,18 +29,8 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 
 ## Channel Binding Object
 
-When using WebSockets, the channel represents the connection. Unlike other protocols that support multiple virtual channels (topics, routing keys, etc.) per connection, WebSockets doesn't support virtual channels or, put it another way, there's only one channel and its characteristics are strongly related to the protocol used for the handshake, i.e., HTTP.
+This object MUST NOT contain any properties. Its name is reserved for future use.
 
-##### Fixed Fields
-
-Field Name | Type | Description
----|:---:|---
-<a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the connection. Its value MUST be either `GET` or `POST`.
-<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
-
-This object MUST contain only the properties defined above.
 
 <a name="operation"></a>
 


### PR DESCRIPTION
**Description**

While it's true that WS doesn't have the concept of channels/topics/message-type, most people don't use a connection per message type but instead, they use a single connection and a subprotocol. Examples of subprotocols are Socket.io, STOMP over WS, custom ones, etc. For that reason, I'm moving all the WS options to the Server Binding Object.

Also, as per the [WebSocket RFC](https://datatracker.ietf.org/doc/html/rfc6455):

> The method of the request MUST be GET, and the HTTP version MUST be at least 1.1.

Therefore, I'm removing the `method` option.