### PR TITLE
docs: clarifying websocket params

### DIFF
--- a/websockets/README.md
+++ b/websockets/README.md
@@ -29,8 +29,8 @@ When using WebSockets, the channel represents the connection. Unlike other proto
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the connection. Its value MUST be either `GET` or `POST`.
-<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key. Each property must be of primitive type (`string`, `boolean`, `integer` or `number`) or must be an `enum` with primitve values.
+<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key. Each property must be of primitive type (`string`, `boolean`, `integer` or `number`) or must be an `enum` with primitve values.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Clarifies that query parameters must be primitive.
 
**Related issue(s)**
#68 #66 