### PR TITLE
feat(kafka): add AVRO type in message key binding

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -6,7 +6,7 @@ This document defines how to describe Kafka-specific information on AsyncAPI.
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `0.2.0`.
 
 
 <a name="server"></a>
@@ -69,7 +69,7 @@ This object contains information about the message representation in Kafka.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageBindingObjectKey"></a>`key` | [Schema Object][schemaObject] | The message key.
+<a name="messageBindingObjectKey"></a>`key` | [Schema Object][schemaObject] / [AVRO file](https://github.com/asyncapi/avro-schema-parser) | The message key.
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -69,7 +69,7 @@ This object contains information about the message representation in Kafka.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageBindingObjectKey"></a>`key` | [Schema Object][schemaObject] / [AVRO file](https://github.com/asyncapi/avro-schema-parser) | The message key.
+<a name="messageBindingObjectKey"></a>`key` | [Schema Object][schemaObject] \| [AVRO Schema Object](https://avro.apache.org/docs/current/spec.html) | The message key. **NOTE**: You can also use the [reference object](https://asyncapi.io/docs/specifications/v2.1.0#referenceObject) way. 
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.

--- a/kafka/json_schemas/message.json
+++ b/kafka/json_schemas/message.json
@@ -31,6 +31,12 @@
         ]
       },
       "bindingVersion": "0.1.0"
+    },
+    {
+      "key": {
+        "$ref": "path/to/user-create.avsc#/UserCreate"
+      },
+      "bindingVersion": "0.2.0"
     }
   ]
 }


### PR DESCRIPTION
Refer to asyncapi/avro-schema-parser#67

Here is the related update due to the support of avro file in kafka key bindings