### PR TITLE
fix: simplify options for kafka operation binding groupId and cliendId

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -35,8 +35,8 @@ This object contains information about the operation representation in Kafka.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationBindingObjectGroupId"></a>`groupId` | [Schema Object][schemaObject] | Id of the consumer group.
-<a name="operationBindingObjectClientId"></a>`clientId` | [Schema Object][schemaObject] | Id of the consumer inside a consumer group.
+<a name="operationBindingObjectGroupId"></a>`groupId` | string \| [string] | Id of the consumer group.
+<a name="operationBindingObjectClientId"></a>`clientId` | string \| [string] | Id of the consumer inside a consumer group.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
@@ -49,12 +49,10 @@ channels:
     publish:
       bindings:
         kafka:
-          groupId:
-            type: string
-            enum: ['myGroupId']
+          groupId: 'myGroupId'
           clientId:
-            type: string
-            enum: ['myClientId']
+            - 'myClientId'
+            - 'myOtherClientId'
           bindingVersion: '0.1.0'
 ```
 

--- a/kafka/json_schemas/operation.json
+++ b/kafka/json_schemas/operation.json
@@ -12,11 +12,31 @@
   },
   "properties": {
     "groupId": {
-      "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
       "description": "Id of the consumer group."
     },
     "clientId": {
-      "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
       "description": "Id of the consumer inside a consumer group."
     },
     "bindingVersion": {
@@ -30,18 +50,11 @@
   },
   "examples": [
     {
-      "groupId": {
-        "type": "string",
-        "enum": [
-          "myGroupId"
-        ]
-      },
-      "clientId": {
-        "type": "string",
-        "enum": [
-          "myClientId"
-        ]
-      },
+      "groupId": "myGroupId",
+      "clientId": [
+        "myClientId",
+        "myOtherClientId"
+      ],
       "bindingVersion": "0.1.0"
     }
   ]


### PR DESCRIPTION
**Description**
Proposal to change the type of the [Kafka Operation Binding](https://github.com/asyncapi/spec/blob/master/examples/streetlights-kafka.yml#L163) `groupId` and `clientId` to allow for a single string or an array of strings.

This would mean that the [official example](https://github.com/asyncapi/spec/blob/master/examples/streetlights-kafka.yml#L163) is valid but still keeps the possibility to enter multiple values if necessary. 

**Related issue(s)**
Resolves #93 