### PR TITLE
feat: add topicSubscriptions to direct destinations.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,10 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-/anypointmq @GeraldLoeffler
-/ibmmq      @rcoppen
-/kafka      @lbroudoux @dalelane
-/solace     @damaru-inc @CameronRushton
-*.json      @KhudaDad414
+/anypointmq/ @GeraldLoeffler
+/ibmmq/      @rcoppen
+/kafka/      @lbroudoux @dalelane
+/solace/     @damaru-inc @CameronRushton
+*.json       @KhudaDad414
 
 * @derberg @fmvilas @github-actions[bot]

--- a/solace/json_schemas/operation.json
+++ b/solace/json_schemas/operation.json
@@ -26,7 +26,7 @@
               "destinationType": {
                 "type": "string",
                 "const": "queue",
-                "description": "If the type is queue, then the subscriber can bind to the queue, which in turn will subscribe to the topic as represented by the channel name."
+                "description": "If the type is queue, then the subscriber can bind to the queue. The queue subscribes to the given topicSubscriptions. If no topicSubscriptions are provied, the queue will subscribe to the topic as represented by the channel name."
               },
               "queue": {
                 "type": "object",
@@ -42,8 +42,12 @@
                       "type": "string"
                     }
                   },
-                  "exclusive": {
-                    "type": "boolean"
+                  "accessType": {
+                    "type": "string",
+                    "enum": [
+                      "exclusive",
+                      "nonexclusive"
+                    ]
                   }
                 }
               }
@@ -54,8 +58,15 @@
               "destinationType": {
                 "type": "string",
                 "const": "topic",
-                "description": "If the type is topic, then the subscriber subscribes to the topic as represented by the channel name."
-              }
+                "description": "If the type is topic, then the subscriber subscribes to the given topicSubscriptions. If no topicSubscriptions are provided, the client will subscribe to the topic as represented by the channel name."
+              },
+              "topicSubscriptions": {
+                "type": "array",
+                "description": "The list of topics that the client subscribes to.",
+                "items": {
+                  "type": "string"
+                }
+          }
             }
           }
         ]
@@ -65,14 +76,14 @@
   "bindingVersion": {
     "type": "string",
     "enum": [
-      "0.1.0"
+      "0.2.0"
     ],
     "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
   },
   "examples": [
     {
-      "bindingVersion": "0.1.0",
-      "bindings": [
+      "bindingVersion": "0.2.0",
+      "destinations": [
         {
           "destinationType": "queue",
           "queue": {
@@ -80,12 +91,14 @@
             "topicSubscriptions": [
               "samples/*"
             ],
-            "exclusive": false
+            "accessType": "nonexclusive"
           }
         },
         {
           "destinationType": "topic",
-          "deliveryMode": "persistent"
+          "topicSubscriptions": [
+            "samples/*"
+          ]
         }
       ]
     }

--- a/solace/json_schemas/server.json
+++ b/solace/json_schemas/server.json
@@ -18,7 +18,7 @@
     "bindingVersion": {
       "type": "string",
       "enum": [
-        "0.1.0"
+        "0.2.0"
       ],
       "description": "The version of this binding."
     }
@@ -26,7 +26,7 @@
   "examples": [
     {
       "msgVpn": "ProdVPN",
-      "bindingVersion": "0.1.0"
+      "bindingVersion": "0.2.0"
     }
   ]
 }


### PR DESCRIPTION

**Description**
The solace binding should have a topicSubscriptions field in the topic destination, just like we have for queues.

Also something was fixed in the schema. The schema had a property called 'exclusive' which should have been 'accessType.'

