### PR TITLE
feat: add support for multiple methods in http bindings

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -21,8 +21,37 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 <a name="channel"></a>
 
 ## Channel Binding Object
+Describes the http binding operation for a particular channel. This http binding object supports [OpenAPI's Path Item Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object) 
 
-This object MUST NOT contain any properties. Its name is reserved for future use.
+##### Example 
+```yaml
+channels:
+  /employees:
+    bindings:
+      http:
+        get:
+          description: 'Get employees data as per the id passed'
+          parameters:
+            - name: ID
+              in: query
+              reqruied: true
+          response:
+            '200':
+              description: A employee data as per ID
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      name: string
+            default:
+              description: Unexpected Error
+              content:
+                application/json:
+                  schema:
+                    type: string
+```
+
 
 
 <a name="operation"></a>

--- a/http/json_schemas/operation.json
+++ b/http/json_schemas/operation.json
@@ -8,26 +8,36 @@
   "patternProperties": {
     "^x-[\\w\\d\\.\\-\\_]+$": {
       "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/specificationExtension"
-    },
-    "^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|TRACE)": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
-          "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
-        },
-        "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
-          "description": "A Schema object containing definitions for each request body parameters."
-        },
-        "response": {
-          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
-          "description": "A Schema object containing the definitions for each response parameter."
-        }
-      }
     }
   },
   "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "request",
+        "response"
+      ],
+      "description": "Required. Type of operation. Its value MUST be either 'request' or 'response'."
+    },
+    "method": {
+      "type": "string",
+      "enum": [
+        "GET",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE",
+        "HEAD",
+        "OPTIONS",
+        "CONNECT",
+        "TRACE"
+      ],
+      "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
+    },
+    "query": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+      "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+    },
     "bindingVersion": {
       "type": "string",
       "enum": [
@@ -36,47 +46,73 @@
       "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
     }
   },
-  "examples": [
+  "required": [
+    "type"
+  ],
+  "oneOf": [
     {
-      "GET": {
-        "query": {
-          "type": "object",
-          "properties": {
-            "userId": {
-              "type": "string"
-            }
-          }
-        },
-        "response": {
-          "type": "object",
-          "properties": {
-            "userId": {
-              "type": "string"
-            },
-            "userName": {
-              "type": "string"
-            }
-          }
+      "properties": {
+        "type": {
+          "const": "request"
         }
       },
-      "POST": {
-        "requestBody": {
-          "type": "object",
-          "properties": {
-            "userName": {
-              "type": "string"
-            }
+      "required": [
+        "method"
+      ]
+    },
+    {
+      "properties": {
+        "is": {
+          "const": "response"
+        }
+      },
+      "not": {
+        "required": [
+          "method"
+        ]
+      }
+    }
+  ],
+  "examples": [
+    {
+      "type": "response",
+      "query": {
+        "type": "object",
+        "required": [
+          "companyId"
+        ],
+        "properties": {
+          "companyId": {
+            "type": "number",
+            "minimum": 1,
+            "description": "The Id of the company."
           }
         },
-        "response": {
-          "type": "object",
-          "properties": {
-            "userId": {
-              "type": "string"
-            }
+        "additionalProperties": false
+      },
+      "bindingVersion": "0.1.0"
+    },
+    {
+      "type": "request",
+      "method": "GET",
+      "query": {
+        "type": "object",
+        "required": [
+          "companyId"
+        ],
+        "properties": {
+          "companyId": {
+            "type": "number",
+            "minimum": 1,
+            "description": "The Id of the company."
           }
-        }
-      }
+        },
+        "additionalProperties": false
+      },
+      "bindingVersion": "0.1.0"
     }
   ]
 }
+
+
+

--- a/http/json_schemas/operation.json
+++ b/http/json_schemas/operation.json
@@ -8,36 +8,26 @@
   "patternProperties": {
     "^x-[\\w\\d\\.\\-\\_]+$": {
       "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/specificationExtension"
+    },
+    "^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|TRACE)": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+          "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
+        },
+        "requestBody": {
+          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+          "description": "A Schema object containing definitions for each request body parameters."
+        },
+        "response": {
+          "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
+          "description": "A Schema object containing the definitions for each response parameter."
+        }
+      }
     }
   },
   "properties": {
-    "type": {
-      "type": "string",
-      "enum": [
-        "request",
-        "response"
-      ],
-      "description": "Required. Type of operation. Its value MUST be either 'request' or 'response'."
-    },
-    "method": {
-      "type": "string",
-      "enum": [
-        "GET",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE",
-        "HEAD",
-        "OPTIONS",
-        "CONNECT",
-        "TRACE"
-      ],
-      "description": "When 'type' is 'request', this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', and 'TRACE'."
-    },
-    "query": {
-      "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
-      "description": "A Schema object containing the definitions for each query parameter. This schema MUST be of type 'object' and have a properties key."
-    },
     "bindingVersion": {
       "type": "string",
       "enum": [
@@ -46,74 +36,47 @@
       "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
     }
   },
-  "required": [
-    "type"
-  ],
-  "oneOf": [
-    {
-      "properties": {
-        "type": {
-          "const": "request"
-        }
-      },
-      "required": [
-        "method"
-      ]
-    },
-    {
-      "properties": {
-        "is": {
-          "const": "response"
-        }
-      },
-      "not": {
-        "required": [
-          "method"
-        ]
-      }
-    }
-  ],
   "examples": [
     {
-      "type": "response",
-      "query": {
-        "type": "object",
-        "required": [
-          "companyId"
-        ],
-        "properties": {
-          "companyId": {
-            "type": "number",
-            "minimum": 1,
-            "description": "The Id of the company."
+      "GET": {
+        "query": {
+          "type": "object",
+          "properties": {
+            "userId": {
+              "type": "string"
+            }
           }
         },
-        "additionalProperties": false
+        "response": {
+          "type": "object",
+          "properties": {
+            "userId": {
+              "type": "string"
+            },
+            "userName": {
+              "type": "string"
+            }
+          }
+        }
       },
-      "bindingVersion": "0.1.0"
-    },
-    {
-      "type": "request",
-      "method": "GET",
-      "query": {
-        "type": "object",
-        "required": [
-          "companyId"
-        ],
-        "properties": {
-          "companyId": {
-            "type": "number",
-            "minimum": 1,
-            "description": "The Id of the company."
+      "POST": {
+        "requestBody": {
+          "type": "object",
+          "properties": {
+            "userName": {
+              "type": "string"
+            }
           }
         },
-        "additionalProperties": false
-      },
-      "bindingVersion": "0.1.0"
+        "response": {
+          "type": "object",
+          "properties": {
+            "userId": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   ]
 }
-
-
-
-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
To support multiple methods in HTTP bindings I am trying to reuse [openAPI's path item object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object). Since [openapi](https://www.openapis.org/) is the most widely adopted specification for HTTP, people coming from openAPI would feel right at home. 

Firstly I will try to showcase how the HTTP binding looks with [openapi path item object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object) and then try to talk about the complications we might face. 

#### Example 
```yaml
channels:
  /employees:
    bindings:
      http:
        post:
          description: 'create a new Employee data'
          requestBody:
            description: 'Employee to create'
            content:
              application/json:
                schema:
                  type: object
                  properties:
                    name: string
          response:
            '200':
              content:
                application/json:
                  schema:
                    type: object
                    properties:
                      ID: string
            default:
              description: Unexpected Error
              content:
                application/json:
                  schema:
                    type: string
        get:
          description: 'Get employees data as per the id passed'
          parameters:
            - name: ID
              in: query
              reqruied: true
          response:
            '200':
              description: A employee data as per ID
              content:
                application/json:
                  schema:
                    type: object
                    properties:
                      name: string
            default:
              description: Unexpected Error
              content:
                application/json:
                  schema:
                    type: string
```
If you have worked with openAPI before it would look very familiar. With this, we can now define multiple methods in HTTP bindings. Also, any tooling that supports openapi should support this as well. 



#### Some Complications 
Now I don't know if these effects or not, these are just things I think make this a bit complicated to understand 
- **payload** vs **schema** - In AsyncAPI we are using [payload](https://github.com/asyncapi/spec/blob/v2.4.0/spec/asyncapi.md#message-object) to define the message and openapi is using [schema](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject) so it could be confusing to people well versed in AsyncAPI specification. 
- [path item object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object) in openapi depends on their [server](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverObject) object which is a clash with asyncapi [server object](https://github.com/asyncapi/spec/blob/v2.4.0/spec/asyncapi.md#serversObject)



Tagging @fmvilas, @KhudaDad414, and @derberg 

**Related issue(s)**
Fixes #2 