### PR TITLE
docs: adapt AsyncAPI version in Solace example

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,10 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
+* @derberg @fmvilas @asyncapi-bot-eve
+
 /anypointmq/ @GeraldLoeffler
 /ibmmq/      @rcoppen
 /kafka/      @lbroudoux @dalelane
 /solace/     @damaru-inc @CameronRushton
 *.json       @KhudaDad414
-
-* @derberg @fmvilas @asyncapi-bot-eve

--- a/solace/README.md
+++ b/solace/README.md
@@ -113,7 +113,7 @@ channels:
       eventType:
         schema:
           type: string
-asyncapi: 2.0.0
+asyncapi: 2.4.0
 info:
   title: HRApp
   version: 0.0.1
@@ -156,7 +156,7 @@ channels:
       eventType:
         schema:
           type: string
-asyncapi: 2.0.0
+asyncapi: 2.4.0
 info:
   title: HRApp
   version: 0.0.1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Solace Binding Protocol has been included with release 2.3.0 of AsyncAPI,
with:
- https://github.com/asyncapi/spec/commit/88abbe0c86611f7e6a8f63cb37768ad45a51a761
- https://github.com/asyncapi/spec/pull/666

Thus, specification example should indicate at least this version.

While here, let's favor last released version 2.4.0, as suggested in https://github.com/asyncapi/bindings/pull/135#issuecomment-1135030435

Note:

Following https://github.com/asyncapi/bindings/pull/135#issuecomment-1134916216, this PR include a first commit to fix code owners orders.

---

Noticed by working on Solace Protocol support on https://bump.sh/asyncapi
