### PR TITLE
feat: add value parameters for websocket bindings

### DIFF
--- a/websockets/README.md
+++ b/websockets/README.md
@@ -6,7 +6,7 @@ This document defines how to describe WebSockets-specific information on AsyncAP
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `0.2.0`.
 
 
 <a name="server"></a>
@@ -36,6 +36,56 @@ Field Name | Type | Description
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
+
+
+## Example
+
+Using binding to send headers and query value 
+```yaml
+channles:
+    /employees
+        bindings:
+            ws:
+                bindingVersion: 0.2.0
+                headerValues:
+                    Authentication: 'bearer Token'
+                queryValues:
+                    employeeId: '234xrf'
+        publish:
+            message:
+                $ref: '#/components/messages/employeeData'
+```
+
+Using binding to define headers and query schema 
+
+```yaml
+channels:
+    /employees
+        bindings:
+            ws:
+                bindingVersion: 0.2.0
+                headers:
+                    type: object
+                    required: [
+                        'Authorization'
+                    ]
+                    properties:
+                        Authorization:
+                            type: string
+                query:
+                    type: object
+                    requried: [
+                        'empployeeId'
+                    ]
+                    properties:
+                        employeeId: string
+        subscribe:
+            message:
+                $ref: '#/components/messages/employeeData'
+
+
+
+```
 
 <a name="operation"></a>
 

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -39,10 +39,10 @@ This object MUST contain only the properties defined above.
 
 #### Passing ENV variables to headers and query 
 
-All string values containting words starting from '$' sign, MUST be replaced with enviornment variables of the same name at runtime. The following variable naming scheme would be followed -
+All string values containing words starting with the '$' sign, MUST be replaced with environment variables of the same name at runtime. The following rules MUST be applied:
 
-- Only uppercase, underscore (_) and digits are allowed for naming the env variable 
-- Enviornment variable should not start with a digit or underscore
+- Environment variables' names MUST use uppercase letters (A-Z), underscore characters (_), or digits (0-9).
+- Environment variables' names SHALL NOT start with a digit (0-9) or an underscore character (_).
 
 ##### Do's 
 - `$TOKEN`

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -38,7 +38,21 @@ Field Name | Type | Description
 This object MUST contain only the properties defined above.
 
 #### Passing ENV variables to headers and query 
-You can pass in enviornment variables to `queryValues` and `headerValues` using `$<variable>` format. Tools will resovle this value using `.env` files. 
+
+All string values containting words starting from '$' sign, MUST be replaced with enviornment variables of the same name at runtime. The following variable naming scheme would be followed -
+
+- Only uppercase, underscore (_) and digits are allowed for naming the env variable 
+- Enviornment variable should not start with a digit or underscore
+
+##### Do's 
+- `$TOKEN`
+- `$GITHUB_TOKEN`
+- `$TOKEN1`
+##### Don'ts 
+- `$ TOKEN`
+- `$1TOKEN`
+- `$token`
+- `$_TOKEN`
 
 
 ## Example

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -31,6 +31,8 @@ Field Name | Type | Description
 <a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the connection. Its value MUST be either `GET` or `POST`.
 <a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
 <a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectQueryValues"></a>`queryValues`| object| An object containing query values.
+<a name="operationBindingObjectHeaderValues"></a>`headerValues`| object | An object containing header values
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -24,7 +24,7 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 
 When using WebSockets, the channel represents the connection. Unlike other protocols that support multiple virtual channels (topics, routing keys, etc.) per connection, WebSockets doesn't support virtual channels or, put it another way, there's only one channel and its characteristics are strongly related to the protocol used for the handshake, i.e., HTTP.
 
-##### Fixed Fields
+#### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
@@ -32,10 +32,13 @@ Field Name | Type | Description
 <a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
 <a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
 <a name="operationBindingObjectQueryValues"></a>`queryValues`| object| An object containing query values.
-<a name="operationBindingObjectHeaderValues"></a>`headerValues`| object | An object containing header values
+<a name="operationBindingObjectHeaderValues"></a>`headerValues`| object | An object containing header values.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
+
+#### Passing ENV variables to headers and query 
+You can pass in enviornment variables to `queryValues` and `headerValues` using `$<variable>` format. Tools will resovle this value using `.env` files. 
 
 
 ## Example
@@ -64,7 +67,7 @@ channels:
                 headerValues:
                     Authentication: 'bearer $TOKEN'
                 queryValues:
-                    employeeId: '$EMP_UD'
+                    employeeId: '$EMP_ID'
         publish:
             message:
                 $ref: '#/components/messages/employeeData'

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -40,27 +40,9 @@ This object MUST contain only the properties defined above.
 
 ## Example
 
-Using binding to send headers and query value 
-```yaml
-channles:
-    /employees
-        bindings:
-            ws:
-                bindingVersion: 0.2.0
-                headerValues:
-                    Authentication: 'bearer Token'
-                queryValues:
-                    employeeId: '234xrf'
-        publish:
-            message:
-                $ref: '#/components/messages/employeeData'
-```
-
-Using binding to define headers and query schema 
-
 ```yaml
 channels:
-    /employees
+    /employees:
         bindings:
             ws:
                 bindingVersion: 0.2.0
@@ -75,16 +57,20 @@ channels:
                 query:
                     type: object
                     requried: [
-                        'empployeeId'
+                        'employeeId'
                     ]
                     properties:
                         employeeId: string
+                headerValues:
+                    Authentication: 'bearer $TOKEN'
+                queryValues:
+                    employeeId: '$EMP_UD'
+        publish:
+            message:
+                $ref: '#/components/messages/employeeData'
         subscribe:
             message:
                 $ref: '#/components/messages/employeeData'
-
-
-
 ```
 
 <a name="operation"></a>

--- a/websockets/json_schemas/channel.json
+++ b/websockets/json_schemas/channel.json
@@ -27,10 +27,23 @@
       "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
       "description": "A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type 'object' and have a 'properties' key."
     },
+    "headerValues": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "queryValues": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "bindingVersion": {
       "type": "string",
       "enum": [
-        "0.1.0"
+        "0.1.0",
+        "0.2.0"
       ],
       "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
     }
@@ -38,7 +51,10 @@
   "examples": [
     {
       "method": "POST",
-      "bindingVersion": "0.1.0"
+      "bindingVersion": "0.2.0",
+      "headerValues": {
+        "Authorization": "bearer token"
+      }
     }
   ]
 }

--- a/websockets/json_schemas/channel.json
+++ b/websockets/json_schemas/channel.json
@@ -29,15 +29,11 @@
     },
     "headerValues": {
       "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "additionalProperties": true
     },
     "queryValues": {
       "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "additionalProperties": true
     },
     "bindingVersion": {
       "type": "string",
@@ -53,7 +49,7 @@
       "method": "POST",
       "bindingVersion": "0.2.0",
       "headerValues": {
-        "Authorization": "bearer token"
+        "Authorization": "bearer $TOKEN"
       }
     }
   ]

--- a/websockets/json_schemas/channel.json
+++ b/websockets/json_schemas/channel.json
@@ -27,14 +27,8 @@
       "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/schema",
       "description": "A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type 'object' and have a 'properties' key."
     },
-    "headerValues": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "queryValues": {
-      "type": "object",
-      "additionalProperties": true
-    },
+    "headerValues": {},
+    "queryValues": {},
     "bindingVersion": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
In [glee](https://github.com/asyncapi/glee/pull/319) we are using WebSocket bindings for validating the headers and query in which case they work fine since current bindings say `query` and `headers` are `schema objects`. After [this PR](https://github.com/asyncapi/glee/pull/319) glee acts like a client so it actually needs to pass headers and query to the server which is something missing in the current [websocket bindings](https://github.com/asyncapi/bindings/blob/master/websockets/README.md). For this, we need the current bindings to support passing actual query and headers data. 



I am opening this PR to add two new parameters, for passing actual headers and query values namely 
- `headerValues`
- `queryValues`


### Example

```yaml
/notification:
  bindings:
    ws:
      headerValues:
        Authorization: "bearer token"
  publish:
    message:
      $ref: '#/components/messages/notification'
```

ps: @fmvilas 


<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->