### PR TITLE
fix: solace bindings - typo "msvVpn" should be "msgVpn"

### DIFF
--- a/solace/README.md
+++ b/solace/README.md
@@ -6,7 +6,7 @@ This document defines how to describe Solace-specific information with AsyncAPI.
 
 ## Version
 
-Current version is `0.2.0`.
+Current version is `0.2.1`.
 
 <a name="server"></a>
 
@@ -14,7 +14,7 @@ Current version is `0.2.0`.
 
 Field Name | Type | Description
 ---|---|---
-`bindingVersion`|String|The current version is 0.2.0
+`bindingVersion`|String|The current version is 0.2.1
 `msgVpn`|String|The Virtual Private Network name on the Solace broker.
 
 
@@ -34,7 +34,7 @@ We need the ability to support several bindings for each operation, see the [Exa
 
 Field Name | Type | Description
 ---|---|---
-`bindingVersion`|String|The current version is 0.2.0
+`bindingVersion`|String|The current version is 0.2.1
 `destinations`|List of Destination Objects|Destination Objects are described next.
 
 ### Destination Object
@@ -92,7 +92,7 @@ channels:
     publish:
       bindings:
         solace:
-          bindingVersion: 0.2.0
+          bindingVersion: 0.2.1
           destinations:
             - destinationType: queue
               queue:
@@ -142,7 +142,7 @@ channels:
     publish:
       bindings:
         solace:
-          bindingVersion: 0.2.0
+          bindingVersion: 0.2.1
           destinations:
             - destinationType: topic
               topicSubscriptions:

--- a/solace/json_schemas/operation.json
+++ b/solace/json_schemas/operation.json
@@ -66,19 +66,19 @@
                 "items": {
                   "type": "string"
                 }
-          }
+              }
             }
           }
         ]
       }
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.2.0"
+      ],
+      "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
     }
-  },
-  "bindingVersion": {
-    "type": "string",
-    "enum": [
-      "0.2.0"
-    ],
-    "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
   },
   "examples": [
     {

--- a/solace/json_schemas/operation.json
+++ b/solace/json_schemas/operation.json
@@ -75,14 +75,14 @@
     "bindingVersion": {
       "type": "string",
       "enum": [
-        "0.2.0"
+        "0.2.1"
       ],
       "description": "The version of this binding. If omitted, \"latest\" MUST be assumed."
     }
   },
   "examples": [
     {
-      "bindingVersion": "0.2.0",
+      "bindingVersion": "0.2.1",
       "destinations": [
         {
           "destinationType": "queue",

--- a/solace/json_schemas/server.json
+++ b/solace/json_schemas/server.json
@@ -11,7 +11,7 @@
     }
   },
   "properties": {
-    "msvVpn": {
+    "msgVpn": {
       "type": "string",
       "description": "The name of the Virtual Private Network to connect to on the Solace broker."
     },

--- a/solace/json_schemas/server.json
+++ b/solace/json_schemas/server.json
@@ -26,7 +26,7 @@
   "examples": [
     {
       "msgVpn": "ProdVPN",
-      "bindingVersion": "0.2.0"
+      "bindingVersion": "0.2.1"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/asyncapi/bindings/issues/153


**Description**

Fixed typo in Solace server binding JSON schema

**Related issue(s)**
Resolves
https://github.com/asyncapi/bindings/issues/153