### PR TITLE
chore: add @smoya, @dalelane, and @char0n as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @derberg @fmvilas @asyncapi-bot-eve
+* @derberg @fmvilas @dalelane @smoya @char0n @asyncapi-bot-eve
 
 /anypointmq/   @GeraldLoeffler
 /ibmmq/        @rcoppen


### PR DESCRIPTION
## Description

Adding @smoya and @char0n as code owners. Also adding @dalelane who seemed to be missing. Even though he's on the kafka binding but as a spec code owner I think he should also be code owner of all the bindings. What do you think?

## Related issues
https://github.com/asyncapi/spec/pull/846
https://github.com/asyncapi/spec-json-schemas/pull/271