### PR TITLE
feat: session expiry interval to mqtt5 bindings

### DIFF
--- a/mqtt5/README.md
+++ b/mqtt5/README.md
@@ -13,9 +13,27 @@ Current version is `0.1.0`.
 
 ## Server Binding Object
 
-This object MUST NOT contain any properties. Its name is reserved for future use.
+This object contains information about the server representation in MQTT5.
 
+##### Fixed Fields
 
+Field Name | Type | Description
+---|:---:|---
+<a name="serverBindingObjectSessionExpiryInterval"></a>`sessionExpiryInterval` | integer | Session Expiry Interval in seconds.
+<a name="serverBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
+
+This object MUST contain only the properties defined above.
+
+##### Example
+
+```yaml
+servers:
+  production:
+    bindings:
+      mqtt5:
+        sessionExpiryInterval: 60
+        bindingVersion: 0.1.0
+```
 
 <a name="channel"></a>
 

--- a/mqtt5/json_schemas/server.json
+++ b/mqtt5/json_schemas/server.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://asyncapi.com/bindings/mqtt5/server.json",
+  "title": "Server Schema",
+  "description": "This object contains information about the server representation in MQTT5.",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[\\w\\d\\.\\-\\_]+$": {
+      "$ref": "https://raw.githubusercontent.com/asyncapi/asyncapi-node/v2.7.7/schemas/2.0.0.json#/definitions/specificationExtension"
+    }
+  },
+  "properties": {
+
+    "sessionExpiryInterval": {
+      "type": "integer",
+      "description": "Session Expiry Interval in seconds."
+    },
+    "bindingVersion": {
+      "type": "string",
+      "enum": [
+        "0.1.0"
+      ],
+      "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+    }
+  },
+  "examples": [
+    {
+      "sessionExpiryInterval": 60,
+      "bindingVersion": "0.1.0"
+    }
+  ]
+}
+  


### PR DESCRIPTION
**Description**

Adds `sessionExpiryInterval` to MQTT5 server bindings, which is required for https://github.com/asyncapi/glee/pull/323