### PR TITLE
fix(ibmmq): make topic field optional

### DIFF
--- a/ibmmq/json_schemas/channel.json
+++ b/ibmmq/json_schemas/channel.json
@@ -84,9 +84,6 @@
       "properties": {
         "destinationType": { "const": "topic" }
       },
-      "required": [
-        "topic"
-      ],
       "not": {
         "required": [
           "queue"


### PR DESCRIPTION
When `destinationType=topic`, `queue` field MUST NOT be present and topic MAY be defined.

Refs #169

---

This change is a reaction to https://github.com/asyncapi/bindings/pull/169#issuecomment-1357795258 and https://github.com/asyncapi/bindings/pull/169#issuecomment-1359075613