### PR TITLE
docs: added Pulsar to the overview in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains the specifications for each AsyncAPI protocol binding.
 * [MQTT binding](./mqtt)
 * [MQTT5 binding](./mqtt5)
 * [NATS binding](./nats)
+* [Pulsar](./pulsar)
 * [Redis binding](./redis)
 * [SNS binding](./sns)
 * [Solace binding](./solace)


### PR DESCRIPTION
Added pulsar to the overview in the readme.

Looks like the readme didn't get updated after the pulsar bindings were added.