### PR TITLE
fix: revert Kafka operation binding to publish

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -122,7 +122,7 @@ This object MUST contain only the properties defined above.
 ```yaml
 channels:
   user-signedup:
-    subscribe:
+    publish:
       bindings:
         kafka:
           groupId:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Based on the articles provided by the AsyncAPI org, specifically the [Demystifying the semantics of Publish and Subscribe](https://www.asyncapi.com/blog/publish-subscribe-semantics) the `publish` binding documents how you (the client) interact with the documenting application through the messaging channel. 

> publish means publish an event to the channel and this application will receive it

For a Kafka consumer you should *publish* to the target channel to interact with a consumer application. Given the operation binding in this specification explicitly describes "consumer" data on the object it seems like it should be using a `publish` binding in the example to avoid confusion.

I use "revert" here because when this operation binding specification was first added it did use `publish` but was changed in a later merge and I'm not sure why.
