### PR TITLE
feat: adapt websockets bindings to v3

### DIFF
--- a/websockets/README.md
+++ b/websockets/README.md
@@ -6,7 +6,7 @@ This document defines how to describe WebSockets-specific information on AsyncAP
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `1.0.0`.
 
 
 <a name="server"></a>
@@ -49,4 +49,4 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 This object MUST NOT contain any properties. Its name is reserved for future use.
 
 
-[schemaObject]: https://www.asyncapi.com/docs/specifications/2.0.0/#schemaObject
+[schemaObject]: https://www.asyncapi.com/docs/specificationsv3.0.0-next-major-spec.12/#schemaObject

--- a/websockets/README.md
+++ b/websockets/README.md
@@ -6,17 +6,13 @@ This document defines how to describe WebSockets-specific information on AsyncAP
 
 ## Version
 
-Current version is `1.0.0`.
-
+Current version is `0.2.0`.
 
 <a name="server"></a>
 
 ## Server Binding Object
 
 This object MUST NOT contain any properties. Its name is reserved for future use.
-
-
-
 
 <a name="channel"></a>
 
@@ -29,8 +25,8 @@ When using WebSockets, the channel represents the connection. Unlike other proto
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the connection. Its value MUST be either `GET` or `POST`.
-<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectQuery"></a>`query` | [Parameters Object][parametersObject] | A Schema object containing the definitions for each query parameter. 
+<a name="operationBindingObjectHeaders"></a>`headers` | [Parameters Object][parametersObject] | A Schema object containing the definitions of the HTTP headers to use when establishing the connection.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
@@ -41,7 +37,6 @@ This object MUST contain only the properties defined above.
 
 This object MUST NOT contain any properties. Its name is reserved for future use.
 
-
 <a name="message"></a>
 
 ## Message Binding Object
@@ -49,4 +44,4 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 This object MUST NOT contain any properties. Its name is reserved for future use.
 
 
-[schemaObject]: https://www.asyncapi.com/docs/specificationsv3.0.0-next-major-spec.12/#schemaObject
+[parametersObject]: https://www.asyncapi.com/docs/specifications/latest/#parametersObject


### PR DESCRIPTION
**Description**
This PR adapts the websockets bindings to v3. This first round of review is just for the general structure changes.

TODO right before final review:

- [x] Adapt examples, if any that contain v2 structure.
- [x] Figure out which version change this constitutes

TODO after merge:
- [ ] Adapt schema files in spec-schema-repo

**Related issue(s)**
Related to https://github.com/asyncapi/bindings/issues/182