### PR TITLE
feat: adapt googlepubsub bindings to v3

### DIFF
--- a/googlepubsub/README.md
+++ b/googlepubsub/README.md
@@ -6,7 +6,7 @@ This document defines how to describe Google Cloud Pub/Sub specific information 
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `0.2.0`.
 
 <a name="channel"></a>
 
@@ -17,12 +17,11 @@ The `Channel Bindings Object` is used to describe the Google Cloud Pub/Sub speci
 
 Field Name | Type | Description
 ---|---|---
-`bindingVersion`|String|The current version is `0.1.0`
+`bindingVersion`|String|The current version is `0.2.0`
 `labels`|Object|An object of key-value pairs _(These are used to categorize Cloud Resources like Cloud Pub/Sub Topics.)_
 `messageRetentionDuration`|String|Indicates the minimum duration to retain a message after it is published to the topic _(Must be a valid [Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).)_
 `messageStoragePolicy`|[Message Storage Policy Object](#message-storage-policy-object)|Policy constraining the set of Google Cloud Platform regions where messages published to the topic may be stored
 `schemaSettings`|[Schema Settings Object](#schema-settings-object)|Settings for validating messages published against a schema
-`topic`|String|The Google Cloud Pub/Sub Topic name
 
 <a name="message-storage-policy-object"></a>
 
@@ -59,17 +58,17 @@ Field Name | Type | Description
 # ...
 channels:
   topic-avro-schema:
+    address: projects/your-project/topics/topic-avro-schema
     bindings:
       googlepubsub:
-        topic: projects/your-project/topics/topic-avro-schema
         schemaSettings:
           encoding: json
           name: projects/your-project/schemas/message-avro
 # ...
   topic-proto-schema:
+    address: projects/your-project/topics/topic-proto-schema
     bindings:
       googlepubsub:
-        topic: projects/your-project/topics/topic-proto-schema
         messageRetentionDuration: 86400s
         messageStoragePolicy:
           allowedPersistenceRegions:
@@ -102,7 +101,7 @@ Object, with AsyncAPI.
 
 Field Name | Type | Description
 ---|---|---
-`bindingVersion`|String|The current version is `0.1.0`
+`bindingVersion`|String|The current version is `0.2.0`
 `attributes`|Object|Attributes for this message _(If this field is empty, the message must contain non-empty data. This can be used to filter messages on the subscription.)_
 `orderingKey`|String|If non-empty, identifies related messages for which publish order should be respected _(For more information, see [ordering messages](https://cloud.google.com/pubsub/docs/ordering).)_
 `schema`|[Schema Definition Object](#schema-definition-object)|Describes the schema used to validate the payload of this message
@@ -120,7 +119,6 @@ payloads using a supported Google Cloud Pub/Sub schema format like Protobuf.
 Field Name | Type | Description
 ---|---|---
 `name`|String|The name of the schema
-`type`|String|The type of the schema
 
 <a name="message-binding-example"></a>
 
@@ -135,25 +133,31 @@ components:
         googlepubsub:
           schema:
             name: projects/your-project/schemas/message-avro
-            type: avro
       contentType: application/json
       name: MessageAvro
       payload:
-        fields:
-        - name: message
-          type: string
-        name: Message
-        type: record
-      schemaFormat: application/vnd.apache.avro+yaml;version=1.9.0
+        schema:
+          fields:
+          - name: message
+            type: string
+          name: Message
+          type: record
+        schemaFormat: application/vnd.apache.avro+yaml;version=1.9.0
     messageProto:
       bindings:
         googlepubsub:
           schema:
             name: projects/your-project/schemas/message-proto
-            type: protobuf
       contentType: application/octet-stream
       name: MessageProto
-      payload: true
+      payload:
+        schema: |
+          syntax = "proto3";
+
+          message Message {
+            required string message = 1;
+          }
+        schemaFormat: application/vnd.google.protobuf;version=3
 # ...
 ```
 


### PR DESCRIPTION
Changes from v2 to v3:

* Bumped the `bindingVersion` values to `0.2.0`
* The `topic` property for the Channel Binding Object is no more and is now provided via the native `address` property of the Channel Object
* Protobuf support now uses the native support by providing the Protobuf definition as an inline string of the `schema` property within the `payload` property of the Message Object and the `schemaFormat` property within the `payload` property of the Message Object now has valid values for Protobuf 2 and 3
* The `type` property for the Message Binding Object is no more as AsyncAPI now natively support Protobuf and this value would duplicate the `schemaFormat` in the `payload` property of the Message Object

See also #182.