### PR TITLE
docs: update FilterPolicy config to match AWS API

### DIFF
--- a/sns/README.md
+++ b/sns/README.md
@@ -113,7 +113,8 @@ We support an array of consumers via the **consumers** field. This allows you to
 |---|:---:|---|
 | <a name="operationBindingObjectProtocol"></a>`protocol` | string | **Required.** The protocol that this endpoint receives messages by. Can be `http`, `https`, `email`, `email-json`, `sms`, `sqs`, `application`, `lambda` or `firehose` |
 | <a name="operationBindingObjectEndpoint"></a>`endpoint` |[identifier](#identifier)| **Required.** The endpoint messages are delivered to. |
-| <a name="operationBindingObjectFilerPolicy"></a>`filterPolicy` | [filterPolicy](#filter-policy) | **Optional.** Only receive a subset of messages from the channel, determined by this policy. |
+| <a name="operationBindingObjectFilterPolicy"></a>`filterPolicy` | object | **Optional.** Only receive a subset of messages from the channel, determined by this policy. |
+| <a name="operationBindingObjectFilterPolicyScope"></a>`filterPolicyScope` | string | **Optional.** Determines whether the FilterPolicy applies to MessageAttributes (default) or MessageBody. |
 | <a name="operationBindingObjectRawMessageDelivery"></a>`rawMessageDelivery` | boolean | **Required.** If *true* AWS SNS attributes are removed from the body, and for SQS, SNS message attributes are copied to SQS message attributes. If *false* the SNS attributes are included in the body. |
 | <a name="operationBindingObjectRedrivePolicy"></a>`redrivePolicy` | [redrivePolicy](#redrive-policy) | **Optional.** Prevent poison pill messages by moving un-processable messages to an SQS dead letter queue. |
 | <a name="operationBindingObjectDeliveryPolicy"></a>`deliveryPolicy` | [deliveryPolicy](#delivery-policy) | **Optional.** Policy for retries to HTTP. The parameter is for that [SNS Subscription](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) and overrides any policy on the [SNS Topic](https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html). |
@@ -131,11 +132,6 @@ We support an array of consumers via the **consumers** field. This allows you to
 | <a name="channelBindingDeliveryPolicyObjectNumMaxDelayRetries"></a>`numMaxDelayRetries` | integer | **Optional.** The number of post-backoff phase retries, with the maximum delay between retries |
 | <a name="channelBindingDeliveryPolicyObjectBackoffFunction"></a>`backoffFunction` | string, one of: arithmetic, exponential, geometric or linear | **Optional.** The algorithm for backoff between retries |
 | <a name="channelBindingDeliveryPolicyObjectMaxReceivesPerSecond"></a>`maxReceivesPerSecond` | integer | **Optional.** The maximum number of deliveries per second, per subscription |
-
-#### Filter Policy
-|Field Name | Type | Description|
-|---|:---:|---|
-| <a name="filterPolicyObjectAttributes"></a>`attributes` |Map(string, array or string or object) | **Required.** A map of a message attribute to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint  |
 
 #### Identifier
 |Field Name | Type | Description|
@@ -221,9 +217,8 @@ channels:
               name: user-signedup-queue # refers to a queue defined in this file, but not shown in this example
             rawMessageDelivery: true  
             filterPolicy:
-              attributes:
-                reason: 
-                  anything-but: password-reset
+              reason: 
+                anything-but: password-reset
             redrivePolicy:
               deadLetterQueue:
                 name: user-signedup-queue-dlq # refers toa queue defined in this file, but not show in this example
@@ -281,9 +276,9 @@ channels:
           endpoint:
             url: http://login.my.com/user/new
           filterPolicy:
-            attributes:
-              reason: 
-                anything-but: password-reset
+            reason: 
+              anything-but: password-reset
+          filterPolicyScope: MessageBody
           deliveryPolicy:
             minDelayTarget: 1
             maxDelayTarget: 120

--- a/sns/json_schemas/operation.json
+++ b/sns/json_schemas/operation.json
@@ -96,7 +96,7 @@
         },
         "filterPolicy": {
           "type": "object",
-          "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+          "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the filterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
           "patternProperties": {
             "^x-[\\w\\d\\.\\-\\_]+$": {
               "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
@@ -121,10 +121,10 @@
         },
         "filterPolicyScope": {
           "type": "string",
-          "description": "Determines whether the filterPolicy applies to MessageAttributes or MessageBody.",
+          "description": "Determines whether the filterPolicy applies to messageAttributes or messageBody.",
           "enum": [
-            "MessageAttributes",
-            "MessageBody"
+            "messageAttributes",
+            "messageBody"
           ],
           "default": "MessageAttributes"
         },

--- a/sns/json_schemas/operation.json
+++ b/sns/json_schemas/operation.json
@@ -96,7 +96,7 @@
         },
         "filterPolicy": {
           "type": "object",
-          "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the filterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+          "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
           "patternProperties": {
             "^x-[\\w\\d\\.\\-\\_]+$": {
               "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
@@ -121,12 +121,12 @@
         },
         "filterPolicyScope": {
           "type": "string",
-          "description": "Determines whether the filterPolicy applies to messageAttributes or messageBody.",
+          "description": "Determines whether the FilterPolicy applies to MessageAttributes or MessageBody.",
           "enum": [
             "messageAttributes",
             "messageBody"
           ],
-          "default": "MessageAttributes"
+          "default": "messageAttributes"
         },
         "rawMessageDelivery": {
           "type": "boolean",

--- a/sns/json_schemas/operation.json
+++ b/sns/json_schemas/operation.json
@@ -123,10 +123,10 @@
           "type": "string",
           "description": "Determines whether the FilterPolicy applies to MessageAttributes or MessageBody.",
           "enum": [
-            "messageAttributes",
-            "messageBody"
+            "MessageAttributes",
+            "MessageBody"
           ],
-          "default": "messageAttributes"
+          "default": "MessageAttributes"
         },
         "rawMessageDelivery": {
           "type": "boolean",
@@ -234,22 +234,21 @@
             "name": "someQueue"
           },
           "filterPolicy": {
-            "attributes": {
-              "store": [
-                "asyncapi_corp"
-              ],
-              "event": [
-                {
-                  "anything-but": "order_cancelled"
-                }
-              ],
-              "customer_interests": [
-                "rugby",
-                "football",
-                "baseball"
-              ]
-            }
+            "store": [
+              "asyncapi_corp"
+            ],
+            "event": [
+              {
+                "anything-but": "order_cancelled"
+              }
+            ],
+            "customer_interests": [
+              "rugby",
+              "football",
+              "baseball"
+            ]
           },
+          "filterPolicyScope": "MessageAttributes",
           "rawMessageDelivery": false,
           "redrivePolicy": {
             "deadLetterQueue": {

--- a/sns/json_schemas/operation.json
+++ b/sns/json_schemas/operation.json
@@ -97,6 +97,9 @@
         "filterPolicy": {
           "$ref": "#/definitions/filterPolicy"
         },
+        "filterPolicyScope": {
+          "$ref": "#/definitions/filterPolicyScope"
+        },
         "rawMessageDelivery": {
           "type": "boolean",
           "description": "If true AWS SNS attributes are removed from the body, and for SQS, SNS message attributes are copied to SQS message attributes. If false the SNS attributes are included in the body."
@@ -169,37 +172,37 @@
     },
     "filterPolicy": {
       "type": "object",
-      "description": "Only receive a subset of messages from the channel, determined by this policy.",
+      "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
       "patternProperties": {
         "^x-[\\w\\d\\.\\-\\_]+$": {
           "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
         }
       },
-      "properties": {
-        "attributes": {
-          "type": "object",
-          "description": "A map of a message attribute to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "object"
-              }
-            ]
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "object"
           }
-        }
-      },
-      "required": [
-        "attributes"
-      ]
+        ]
+      }
+    },
+    "filterPolicyScope": {
+      "type": "string",
+      "description": "Determines whether the filterPolicy applies to MessageAttributes or MessageBody.",
+      "enum": [
+        "MessageAttributes",
+        "MessageBody"
+      ],
+      "default": "MessageAttributes"
     },
     "redrivePolicy": {
       "type": "object",

--- a/sns/json_schemas/operation.json
+++ b/sns/json_schemas/operation.json
@@ -95,10 +95,38 @@
           "$ref": "#/definitions/identifier"
         },
         "filterPolicy": {
-          "$ref": "#/definitions/filterPolicy"
+          "type": "object",
+          "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
+          "patternProperties": {
+            "^x-[\\w\\d\\.\\-\\_]+$": {
+              "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
+            }
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
         },
         "filterPolicyScope": {
-          "$ref": "#/definitions/filterPolicyScope"
+          "type": "string",
+          "description": "Determines whether the filterPolicy applies to MessageAttributes or MessageBody.",
+          "enum": [
+            "MessageAttributes",
+            "MessageBody"
+          ],
+          "default": "MessageAttributes"
         },
         "rawMessageDelivery": {
           "type": "boolean",
@@ -169,40 +197,6 @@
           "description": "The maximum number of deliveries per second, per subscription."
         }
       }
-    },
-    "filterPolicy": {
-      "type": "object",
-      "description": "Only receive a subset of messages from the channel, determined by this policy. Depending on the FilterPolicyScope, a map of either a message attribute or message body to an array of possible matches. The match may be a simple string for an exact match, but it may also be an object that represents a constraint and values for that constraint.",
-      "patternProperties": {
-        "^x-[\\w\\d\\.\\-\\_]+$": {
-          "$ref": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/v2.14.0/schemas/2.4.0.json#/definitions/specificationExtension"
-        }
-      },
-      "additionalProperties": {
-        "oneOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "object"
-          }
-        ]
-      }
-    },
-    "filterPolicyScope": {
-      "type": "string",
-      "description": "Determines whether the filterPolicy applies to MessageAttributes or MessageBody.",
-      "enum": [
-        "MessageAttributes",
-        "MessageBody"
-      ],
-      "default": "MessageAttributes"
     },
     "redrivePolicy": {
       "type": "object",


### PR DESCRIPTION
Currently, filterPolicy configuration outlined in this file does not match what is outlined in the AWS documentation and API - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html. The `filterPolicy` should only contain the JSON policy, so no need for the `attributes` property; which in itself was confusing as the policy can apply to the message attributes or body.

Further to this, this definition file was missing the `filterPolicyScope` which is needed to determine whether the user wishes to filter on the message attributes or the body.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->