### PR TITLE
feat: enable additional properties for topicConfigurationObject

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -6,7 +6,7 @@ This document defines how to describe Kafka-specific information on AsyncAPI.
 
 ## Version
 
-Current version is `0.4.0`.
+Current version is `0.5.0`.
 
 
 <a name="server"></a>
@@ -88,7 +88,7 @@ Field Name |  Type   |                                                          
 <a name="topicConfigurationDeleteRetentionBytes"></a>`delete.retention.ms` | integer |             The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.                                               |        OPTIONAL         | see kafka documentation
 <a name="topicConfigurationMaxMessageBytes"></a>`max.message.bytes` | integer |                    The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.                                      |        OPTIONAL         | see kafka documentation
 
-This object MUST contain only the properties defined above.
+This object MAY contain the properties defined above including optional additional properties.
 
 ##### Example
 

--- a/kafka/json_schemas/channel.json
+++ b/kafka/json_schemas/channel.json
@@ -28,7 +28,7 @@
       "topicConfiguration" : {
         "description": "Topic configuration properties that are relevant for the API.",
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "cleanup.policy": {
             "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Updated **additionalProperties** as **true** for the **topicConfigurationObject** due to the existence of several vendor-specific configuration properties (e.g. confluent.schema.validation, confluent.value.subject.name.strategy, confluent.key.subject.name.strategy).
- This change was proposed in one of the old [issues](https://github.com/asyncapi/bindings/issues/163) and it was approved but I believe the **additionalProperties** bit got missed by mistake.
- Please let me know if there is any obstacle to enabling that.

[<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->](https://github.com/asyncapi/bindings/issues/163)