### PR TITLE
docs: fix incorrect example for AMQP

### DIFF
--- a/amqp/README.md
+++ b/amqp/README.md
@@ -54,12 +54,6 @@ channels:
     bindings:
       amqp:
         is: routingKey
-        queue:
-          name: my-queue-name
-          durable: true
-          exclusive: true
-          autoDelete: false
-          vhost: /
         exchange:
           name: myExchange
           type: topic
@@ -69,6 +63,21 @@ channels:
         bindingVersion: 0.3.0
 ```
 
+```yaml
+channels:
+  userSignup:
+    address: 'user/signup'
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          name: my-queue-name
+          durable: true
+          exclusive: true
+          autoDelete: false
+          vhost: /
+        bindingVersion: 0.3.0
+```
 
 <a name="operation"></a>
 


### PR DESCRIPTION
According to the JSON Schema files, you are only allowed to use exchange or queue depending on the `is`: https://github.com/asyncapi/spec-json-schemas/blob/287ed2846a764ac6ffce1d5034a9e3e47853a247/bindings/amqp/0.3.0/channel.json#L84

You cannot have both, which makes the example invalid.