### PR TITLE
feat: add HTTP status code

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -71,7 +71,7 @@ This object contains information about the message representation in HTTP.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type `object` and have a `properties` key.
-<a name="messageBindingObjectStatusCode"></a>`statusCode` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
+<a name="messageBindingObjectStatusCode"></a>`statusCode` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [operation reply object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject) as they define the status code for the response, in all other cases this can safely be ignored. 
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.

--- a/http/README.md
+++ b/http/README.md
@@ -21,7 +21,6 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 
 This object MUST NOT contain any properties. Its name is reserved for future use.
 
-
 <a name="operation"></a>
 
 ## Operation Binding Object
@@ -61,7 +60,6 @@ operations:
         bindingVersion: '0.3.0'
 ```
 
-
 <a name="message"></a>
 
 ## Message Binding Object
@@ -73,11 +71,10 @@ This object contains information about the message representation in HTTP.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type `object` and have a `properties` key.
-<a name="messageBindingObjectStatusCode"></a>`status-code` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
+<a name="messageBindingObjectStatusCode"></a>`statusCode` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
-
 
 ```yaml
 channels:
@@ -87,7 +84,7 @@ channels:
       testMessage:
         bindings:
           http:
-            status-code: 200
+            statusCode: 200
             headers:
               type: object
               properties:

--- a/http/README.md
+++ b/http/README.md
@@ -71,7 +71,7 @@ This object contains information about the message representation in HTTP.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type `object` and have a `properties` key.
-<a name="messageBindingObjectStatusCode"></a>`statusCode` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [operation reply object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject) as they define the status code for the response, in all other cases this can safely be ignored. 
+<a name="messageBindingObjectStatusCode"></a>`statusCode` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes). `statusCode` is only relevant for messages referenced by the [Operation Reply Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationReplyObject), as it defines the status code for the response. In all other cases, this value can be safely ignored.
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.

--- a/http/README.md
+++ b/http/README.md
@@ -44,7 +44,7 @@ channels:
     address: /employees
 operations:
   employees:
-    action: send:
+    action: send
     bindings:
       http:
         method: GET
@@ -58,7 +58,7 @@ operations:
               minimum: 1
               description: The Id of the company.
           additionalProperties: false
-        bindingVersion: '0.2.0'
+        bindingVersion: '0.3.0'
 ```
 
 
@@ -94,7 +94,7 @@ channels:
                 Content-Type:
                   type: string
                   enum: ['application/json']
-            bindingVersion: '0.2.0'
+            bindingVersion: '0.3.0'
 ```
 
 [schemaObject]: https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md#schemaObject

--- a/http/README.md
+++ b/http/README.md
@@ -6,7 +6,7 @@ This document defines how to describe HTTP-specific information on AsyncAPI.
 
 ## Version
 
-Current version is `0.2.0`.
+Current version is `0.3.0`.
 
 
 <a name="server"></a>
@@ -73,6 +73,7 @@ This object contains information about the message representation in HTTP.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type `object` and have a `properties` key.
+<a name="messageBindingObjectStatusCode"></a>`status-code` | number | The HTTP response status code according to [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
@@ -86,6 +87,7 @@ channels:
       testMessage:
         bindings:
           http:
+            status-code: 200
             headers:
               type: object
               properties:


### PR DESCRIPTION
**Description**
This PR adds the `statusCode` property to the message object.

The reason for adding it to the message object and not the operation object, is that it feels more natural, as the status code belong to each message being send.
```
...
channels:
  HttpCustomersChannel:
    address: /customers
    messages:
      HttpCustomersGetMessageResponse:
        description: OK
        payload:
          $ref: '#/components/schemas/CustomerPaginated'
        bindings:
          http:
            statusCode: 200
            bindingVersion: '0.3.0'

      HttpCustomersGetMessageResponse:
        description: Server error, could not complete request
        payload:
          $ref: '#/components/schemas/SomeError'
        bindings:
          http:
            statusCode: 500
            bindingVersion: '0.3.0'

operations:
  GetCustomers:
    action: send
    channel:
       $ref: #/channels/HttpCustomersChannel
    bindings:
      http:
        method: GET
        bindingVersion: '0.3.0'
```

**Related issue(s)**
Fixes https://github.com/asyncapi/bindings/issues/234