### PR TITLE
fix: remove required queues property

### DIFF
--- a/sqs/README.md
+++ b/sqs/README.md
@@ -12,7 +12,7 @@ For publish-subscribe scenarios, use as a **publish** Operation Binding Object, 
 
 ## Version
 
-Current version is `0.2.0`.
+Current version is `0.3.0`.
 
 <a name="server"></a>
 
@@ -109,7 +109,7 @@ On an Operation Binding Object we support an array of Queue objects. Members of 
 ### Fields
 |Field Name | Type | Description|
 |---|:---:|---|
-| <a name="channelBindingObjectQueue"></a>`queues` | [[Queue](#queue)]| **Required.** Queue objects that are either the *endpoint* for an SNS Operation Binding Object, or the *deadLetterQueue* of the SQS Operation Binding Object |
+| <a name="channelBindingObjectQueue"></a>`queues` | [[Queue](#queue)]| Queue objects that are either the *endpoint* for an SNS Operation Binding Object, or the *deadLetterQueue* of the SQS Operation Binding Object |
 |<a name="channelBindingObjectBindingVersion"></a>`bindingVersion` | string | **Optional**, defaults to `latest`. The version of this binding.|
 
 ### Examples


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

On reviewing the binding it seems the `required: true` status for the `queues` property of the `sqs` binding was not intended. There were examples from the beginning that show, for protocol ONLY documentation purposes that `queues` property could be undefined.
```yaml
publish:
  bindings:
   sqs: {}
```

This PR fixes this requirement so that linting and validation tools that build from bindings specifications can function correctly.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->