### PR TITLE
chore: add GreenRover as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @derberg @fmvilas @dalelane @smoya @char0n @asyncapi-bot-eve
+* @derberg @fmvilas @dalelane @smoya @char0n @asyncapi-bot-eve @GreenRover
 
 /anypointmq/   @mboss37 @GeraldLoeffler
 /ibmmq/        @rcoppen


### PR DESCRIPTION
Add me as code owner. As discussed in: https://github.com/asyncapi/spec/issues/1008