### PR TITLE
feat: support `sse` protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains the specifications for each AsyncAPI protocol binding.
 * [NATS binding](./nats)
 * [Pulsar](./pulsar)
 * [Redis binding](./redis)
+* [Server-Sent Events binding](./sse)
 * [SNS binding](./sns)
 * [Solace binding](./solace)
 * [SQS binding](./sqs)

--- a/sse/README.md
+++ b/sse/README.md
@@ -51,9 +51,9 @@ This object contains information about the message representation in SSE.
 ##### Fixed Fields
 
 Field Name | Type | Description
----|:---:|:---:|---
-<a name="messageBindingObjectEventType"></a>`event` | string | Server-sent event type, defaults to `message` if omitted, by the [SSE specification](protocolSpecification). |
-<a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | | The version of this binding. If omitted, "latest" MUST be assumed.
+---|:---:|---
+<a name="messageBindingObjectEventType"></a>`event` | string | Server-sent event type, defaults to `message` if omitted, by the [SSE specification][protocolSpecification]. |
+<a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
 

--- a/sse/README.md
+++ b/sse/README.md
@@ -4,7 +4,7 @@ This document defines how to describe Server Sent Events-specific information on
 
 See the [Server-Sent Events protocol specification][protocolSpecification].
 
-Server-Sent Events requires `http` protocol, so the SSE [Message Binding Object](#message) below is appropriate for Servers with protocol `http`.
+Server-Sent Events requires `http` protocol, so the SSE [Message Binding Object](#message) below is appropriate for AsyncAPI Servers with protocol `http` or `https`.
 
 <a name="version"></a>
 

--- a/sse/README.md
+++ b/sse/README.md
@@ -28,7 +28,6 @@ When using Server Sent Events, the channel represents a single logical message s
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the request. Its value MUST be `GET`.
 <a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
 <a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions of the HTTP headers to use when establishing the request. This schema MUST be of type `object` and have a `properties` key.
 <a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.

--- a/sse/README.md
+++ b/sse/README.md
@@ -4,6 +4,8 @@ This document defines how to describe Server Sent Events-specific information on
 
 See the [Server-Sent Events protocol specification][protocolSpecification].
 
+Server-Sent Events requires `http` protocol, so the SSE [Message Binding Object](#message) below is appropriate for Servers with protocol `http`.
+
 <a name="version"></a>
 
 ## Version
@@ -22,17 +24,8 @@ This object MUST NOT contain any properties. Its name is reserved for future use
 
 ## Channel Binding Object
 
-When using Server Sent Events, the channel represents a single logical message stream flowing from server to client. 
+This object MUST NOT contain any properties. Its name is reserved for future use.
 
-##### Fixed Fields
-
-Field Name | Type | Description
----|:---:|---
-<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions of the HTTP headers to use when establishing the request. This schema MUST be of type `object` and have a `properties` key.
-<a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
-
-This object MUST contain only the properties defined above.
 
 <a name="operation"></a>
 
@@ -51,12 +44,10 @@ This object contains information about the message representation in SSE.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageBindingObjectEventType"></a>`event` | string | Server-sent event type, defaults to `message` if omitted, by the [SSE specification][protocolSpecification]. |
+<a name="messageBindingObjectEventType"></a>`event` | string | Server-sent event type, typically `message`, to specify allowed SSE message types. |
 <a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
 
 This object MUST contain only the properties defined above.
 
 
-[schemaObject]: https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md#schemaObject
-[referenceObject]: https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md#referenceObject
 [protocolSpecification]: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events

--- a/sse/README.md
+++ b/sse/README.md
@@ -2,7 +2,7 @@
 
 This document defines how to describe Server Sent Events-specific information on AsyncAPI.
 
-See the [Server-Sent Events protocol specification](protocolSpecification).
+See the [Server-Sent Events protocol specification][protocolSpecification].
 
 <a name="version"></a>
 

--- a/sse/README.md
+++ b/sse/README.md
@@ -1,0 +1,63 @@
+# Server Sent Events Bindings
+
+This document defines how to describe Server Sent Events-specific information on AsyncAPI.
+
+See the [Server-Sent Events protocol specification](protocolSpecification).
+
+<a name="version"></a>
+
+## Version
+
+Current version is `0.1.0`.
+
+
+<a name="server"></a>
+
+## Server Binding Object
+
+This object MUST NOT contain any properties. Its name is reserved for future use.
+
+
+<a name="channel"></a>
+
+## Channel Binding Object
+
+When using Server Sent Events, the channel represents a single logical message stream flowing from server to client. 
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|---
+<a name="operationBindingObjectMethod"></a>`method` | string | The HTTP method to use when establishing the request. Its value MUST be `GET`.
+<a name="operationBindingObjectQuery"></a>`query` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions for each query parameter. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectHeaders"></a>`headers` | [Schema Object][schemaObject] \| [Reference Object](referenceObject) | A Schema object containing the definitions of the HTTP headers to use when establishing the request. This schema MUST be of type `object` and have a `properties` key.
+<a name="operationBindingObjectBindingVersion"></a>`bindingVersion` | string | The version of this binding. If omitted, "latest" MUST be assumed.
+
+This object MUST contain only the properties defined above.
+
+<a name="operation"></a>
+
+## Operation Binding Object
+
+This object MUST NOT contain any properties. Its name is reserved for future use.
+
+
+<a name="message"></a>
+
+## Message Binding Object
+
+This object contains information about the message representation in SSE.
+
+##### Fixed Fields
+
+Field Name | Type | Description
+---|:---:|:---:|---
+<a name="messageBindingObjectEventType"></a>`event` | string | Server-sent event type, defaults to `message` if omitted, by the [SSE specification](protocolSpecification). |
+<a name="messageBindingObjectBindingVersion"></a>`bindingVersion` | string | | The version of this binding. If omitted, "latest" MUST be assumed.
+
+This object MUST contain only the properties defined above.
+
+
+[schemaObject]: https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md#schemaObject
+[referenceObject]: https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md#referenceObject
+[protocolSpecification]: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events


### PR DESCRIPTION
**Description**
- Added `sse` message binding object
- Uses `http` protocol in server definition

Note: we are in the process of testing these proposed changes with `zilla` open source project to confirm they are suffcient to support `sse` message validation, etc.

See https://github.com/aklivity/zilla/issues/952