### PR TITLE
docs: update aws policy statement

### DIFF
--- a/sns/README.md
+++ b/sns/README.md
@@ -6,7 +6,7 @@ This document defines how to describe SNS-specific information on AsyncAPI.
 
 ## Version
 
-Current version is `0.1.0`.
+Current version is `0.2.0`.
 
 
 <a name="server"></a>
@@ -52,8 +52,10 @@ SNS supports many optional properties. To mark a channel as SNS, but use default
 |Field Name | Type | Description|
 |---|:---:|---|
 | <a name="channelBindingPolicyStatementObjectEffect"></a>`effect` | string |**Required.** Either "Allow" or "Deny"|
-| <a name="channelBindingPolicyStatementObjectPrincipal"></a>`principal` | string or array of string |**Required.** The AWS account or resource ARN that this statement applies to|
+| <a name="channelBindingPolicyStatementObjectPrincipal"></a>`principal` | string or AWS principal property containing a string or string array |**Required.** The AWS account(s) or resource ARN(s) that the statement applies to|
 | <a name="channelBindingPolicyStatementObjectAction"></a>`action` | string or array of string |**Required.** The SNS permission being allowed or denied e.g. sns:Publish|
+| <a name="channelBindingPolicyStatementObjectAction"></a>`resource` | string or array of string |**Optional.** The resource(s) that this policy applies to|
+| <a name="channelBindingPolicyStatementObjectAction"></a>`condition` | object or list of objects |**Optional.** Specific circumstances under which the policy grants permission|
 
 ##### Examples
 

--- a/sqs/README.md
+++ b/sqs/README.md
@@ -12,7 +12,7 @@ For publish-subscribe scenarios, use as a **publish** Operation Binding Object, 
 
 ## Version
 
-Current version is `0.2.0`.
+Current version is `0.3.0`.
 
 <a name="server"></a>
 
@@ -79,8 +79,10 @@ An SQS queue can set up a Dead Letter Queue as part of a Redelivery Policy. To s
 |Field Name | Type | Description|
 |---|:---:|---|
 | <a name="channelBindingPolicyStatementObjectEffect"></a>`effect` | string |**Required.** Either "Allow" or "Deny"|
-| <a name="channelBindingPolicyStatementObjectPrincipal"></a>`principal` | string or array of string |**Required.** The AWS account or resource ARN that this statement applies to|
-| <a name="channelBindingPolicyStatementObjectAction"></a>`action` | string or array of string |**Required.** The SQS permission being allowed or denied e.g. sqs:ReceiveMessage |
+| <a name="channelBindingPolicyStatementObjectPrincipal"></a>`principal` | string or AWS principal property containing a string or string array |**Required.** The AWS account(s) or resource ARN(s) that the statement applies to|
+| <a name="channelBindingPolicyStatementObjectAction"></a>`action` | string or array of string |**Required.** The SNS permission being allowed or denied e.g. sns:Publish|
+| <a name="channelBindingPolicyStatementObjectAction"></a>`resource` | string or array of string |**Optional.** The resource(s) that this policy applies to|
+| <a name="channelBindingPolicyStatementObjectAction"></a>`condition` | object or list of objects |**Optional.** Specific circumstances under which the policy grants permission|
 
 
 <a name="operation"></a>


### PR DESCRIPTION
**Description**

The current AWS policy binding configuration doesn't match what is offered by AWS when configuring IAM policies. Condition and Resource are missing and Principal isn't fully fleshed out. This PR addresses this by extending the binding configuration for SNS and SQS.

Related spec JSON schema PR - https://github.com/asyncapi/spec-json-schemas/pull/553

**Related issue(s)**
N/A